### PR TITLE
Fix step navigation and defer result display until diagnostics

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -10,10 +10,48 @@ document.addEventListener('DOMContentLoaded', () => {
   D.renderDiagnosticsList();
   I.setupCivVisibility();
   I.setupContinueHandler();
+
+  const stepIds = ['stepArea', 'stepType', 'stepPurpose', 'stepDiags'];
+  let currentStep = 0;
+
+  const resultCard = H.q('resultCard');
+
+  const showStep = (index) => {
+    currentStep = Math.min(Math.max(index, 0), stepIds.length - 1);
+    stepIds.forEach((id, idx) => {
+      const el = H.q(id);
+      if (!el) return;
+      el.style.display = idx === currentStep ? '' : 'none';
+    });
+    if (resultCard) {
+      resultCard.style.display = currentStep >= stepIds.length - 1 ? '' : 'none';
+    }
+    if (currentStep === stepIds.length - 1) {
+      D.renderDiagnosticsList();
+    }
+  };
+
+  const stepTriggers = [
+    ['nextToType', 1],
+    ['nextToPurpose', 2],
+    ['nextToDiags', 3]
+  ];
+  stepTriggers.forEach(([btnId, targetIndex]) => {
+    H.safeOn(btnId, 'click', () => showStep(targetIndex));
+  });
+
+  // ensure initial visibility reflects JS controlled steps
+  showStep(currentStep);
+
+  document.querySelectorAll('input[name="purpose"]').forEach((radio) => {
+    radio.addEventListener('change', () => {
+      D.renderDiagnosticsList();
+    });
+  });
+
   // wire calculate button to renderResult and to show invoice only after calc
   H.safeOn('calc','click', () => {
     C.renderResult();
     const inv = H.q('stepInvoice'); if (inv) inv.style.display = '';
   });
-  // attach other step navigation manually if needed (or keep step logic inside invoice.js / steps.js)
 });

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       <div id="diagnosticsList" class="row" style="flex-wrap:wrap; gap:8px;"></div>
     </div>
 
-    <div class="card">
+    <div class="card" id="resultCard" style="display:none;">
       <div class="row" style="justify-content: space-between; align-items: center;">
         <h2 style="margin:0;">Result</h2>
         <button id="calc" class="btn">Calculate</button>


### PR DESCRIPTION
## Summary
- add wizard step navigation handlers so each Next button reveals the proper step
- keep the result card hidden until the diagnostics step and refresh the list when entering it

## Testing
- Manual QA: navigated through the wizard and confirmed Calculate only appears after step 4

------
https://chatgpt.com/codex/tasks/task_e_68e7615d1e70832db725dee4631086e0